### PR TITLE
Python3 compatibility of Reader class

### DIFF
--- a/src/python/pyLCIO/io/Reader.py
+++ b/src/python/pyLCIO/io/Reader.py
@@ -26,7 +26,7 @@ class Reader( object ):
             self.addFileList( fileName )
     
     def __iter__( self ):
-        return self
+        return self.reader.__iter__()
     
     def getNumberOfEvents( self ):
         ''' Get the number of events in the stream '''


### PR DESCRIPTION
Changed the __iter__ method to follow the Python 3 convention


BEGINRELEASENOTES
* Python3 compatibility of Reader class
ENDRELEASENOTES